### PR TITLE
Remove unnecessary rxjs imports

### DIFF
--- a/src/app/gallery/gallery.component.ts
+++ b/src/app/gallery/gallery.component.ts
@@ -3,9 +3,8 @@ import {
     ChangeDetectorRef, QueryList, OnInit, Input, SimpleChanges, OnChanges, Output, EventEmitter, OnDestroy
 } from "@angular/core"
 import {Http, Response} from "@angular/http"
-import "rxjs/Rx"
 import {ImageService} from "../services/image.service"
-import {Subscription} from 'rxjs';
+import {Subscription} from 'rxjs/Subscription';
 
 @Component({
     selector: 'gallery',
@@ -35,7 +34,7 @@ export class GalleryComponent implements OnInit, OnDestroy, OnChanges {
     private minimalQualityCategory = 'preview_xxs'
     private viewerSubscription: Subscription;
 
-    constructor(private ImageService: ImageService, private http: Http, private ChangeDetectorRef: ChangeDetectorRef, elementRef: ElementRef) {
+    constructor(private ImageService: ImageService, private http: Http, private ChangeDetectorRef: ChangeDetectorRef) {
     }
 
     public ngOnInit() {

--- a/src/app/services/image.service.ts
+++ b/src/app/services/image.service.ts
@@ -1,5 +1,6 @@
 import {Injectable} from '@angular/core';
-import {Subject, Observable} from "rxjs";
+import {Observable} from "rxjs/Observable";
+import {Subject} from "rxjs/Subject";
 
 @Injectable()
 export class ImageService {

--- a/src/app/viewer/viewer.component.ts
+++ b/src/app/viewer/viewer.component.ts
@@ -6,7 +6,6 @@ import {
     transition,
     animate
 } from "@angular/core"
-import "rxjs/Rx"
 import {ImageService} from "../services/image.service"
 
 @Component({


### PR DESCRIPTION
For performance reasons it's better to only import the types of rxjs which are actually used in the component. This way, no unused operators are put in the resulting bundle. In this case we can save 160kB in the resulting verdor.bundle.js. 