### PR TITLE
Added support for multiple galleries

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Add a flag to define the order of the images inside the gallery
 
 `-c` sort by primary image color
 
-Additional optional parameter to support multiple galeries. Add it if you want to put your image in a separate gallery.
+Additional optional parameter to support multiple galleries. Add it if you want to put your images into a separate gallery.
 
 `--gName=yourGalleryName` 
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,17 @@ Add a flag to define the order of the images inside the gallery
 
 `-c` sort by primary image color
 
+Additional optional parameter to support multiple galeries. Add it if you want to put your image in a separate gallery.
+
+`--gName=yourGalleryName` 
+
 #### 6. Embed gallery in your template
 
 ```javascript
 <gallery 
     [flexBorderSize]="3" 
-    [flexImageSize]="7" 
+    [flexImageSize]="7"
+    [galleryName]="yourGalleryName" 
     (viewerChange)="yourNotificationFunction($event)">
 </gallery>
 ```

--- a/misc/convert.js
+++ b/misc/convert.js
@@ -24,6 +24,13 @@ var resolutions = [
 ];
 
 function init() {
+    if(argv["gName"]){
+        console.log(JSON.stringify(argv));
+        let galleryName = argv['gName']
+        console.log(`Gallery name provided - '${galleryName}'. Images to be created in the '${galleryName}' subfolder`);
+        assetsAbsoluteBasePath = assetsAbsoluteBasePath + argv['gName'] + "/";
+        previewRelativePath = previewRelativePath + argv['gName'] + "/";
+    }
     if (argv['_'].length == 0) {
         toConvertAbsoluteBasePath = projectRoot + "/images_to_convert";
         console.log('No path specified! Defaulting to ' + toConvertAbsoluteBasePath)

--- a/misc/convert.js
+++ b/misc/convert.js
@@ -25,7 +25,6 @@ var resolutions = [
 
 function init() {
     if(argv["gName"]){
-        console.log(JSON.stringify(argv));
         let galleryName = argv['gName']
         console.log(`Gallery name provided - '${galleryName}'. Images to be created in the '${galleryName}' subfolder`);
         assetsAbsoluteBasePath = assetsAbsoluteBasePath + argv['gName'] + "/";

--- a/src/app/demo/demo.component.html
+++ b/src/app/demo/demo.component.html
@@ -4,10 +4,10 @@
         <a class="github-button" href="https://github.com/benjaminbrandmeier/angular2-image-gallery" data-style="mega" data-count-href="/benjaminbrandmeier/angular2-image-gallery/stargazers" data-count-api="/repos/benjaminbrandmeier/angular2-image-gallery#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star benjaminbrandmeier/angular2-image-gallery on GitHub">Star</a>
     </div>
     <md-input-container>
-        <input md-input [(ngModel)]="flexBorderSize" type="number" min="1" max="50" placeholder="Space between images">
+        <input mdInput [(ngModel)]="flexBorderSize" type="number" min="1" max="50" placeholder="Space between images">
     </md-input-container>
     <md-input-container>
-        <input md-input [(ngModel)]="flexImageSize" type="number" min="0" max="50" placeholder="Image size">
+        <input mdInput [(ngModel)]="flexImageSize" type="number" min="0" max="50" placeholder="Image size">
     </md-input-container>
 
     <gallery (viewerChange)="onViewerVisibilityChanged($event)" [flexBorderSize]="flexBorderSize" [flexImageSize]="flexImageSize"></gallery>

--- a/src/app/demo/demo.component.ts
+++ b/src/app/demo/demo.component.ts
@@ -11,6 +11,7 @@ export class DemoComponent implements OnInit {
 
   private flexBorderSize: number = 3
   private flexImageSize: number = 7
+  private galleryName: string = '';
 
   ngOnInit() {
   }

--- a/src/app/gallery/gallery.component.ts
+++ b/src/app/gallery/gallery.component.ts
@@ -14,6 +14,7 @@ import {Subscription} from 'rxjs/Subscription';
 export class GalleryComponent implements OnInit, OnDestroy, OnChanges {
     @Input('flexBorderSize') providedImageMargin: number = 3
     @Input('flexImageSize') providedImageSize: number = 7
+    @Input('galleryName') providedGalleryName: string = '';
 
     @Output() viewerChange = new EventEmitter<boolean>()
 
@@ -28,7 +29,8 @@ export class GalleryComponent implements OnInit, OnDestroy, OnChanges {
         this.render()
     }
 
-    private imageDataFilePath: string = 'assets/img/gallery/data.json'
+    private imageDataFilePath: string = 'assets/img/gallery/'
+    private dataFileName: string = 'data.json'
     private images: any[] = []
     private gallery: any[] = []
     private minimalQualityCategory = 'preview_xxs'
@@ -60,6 +62,10 @@ export class GalleryComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     private fetchDataAndRender() {
+        this.imageDataFilePath = this.providedGalleryName != '' ? 
+            this.imageDataFilePath + this.providedGalleryName + '/' + this.dataFileName : 
+            this.imageDataFilePath + this.dataFileName
+
         this.http.get(this.imageDataFilePath)
             .map((res: Response) => res.json())
             .subscribe(


### PR DESCRIPTION
In order to create a separate gallery you need to add `--gName=yourGalleryName` when running the conversion script. 

Later when using the library specify the same gallery name: 
`<gallery (viewerChange)="onViewerVisibilityChanged($event)" [flexBorderSize]="flexBorderSize" [flexImageSize]="flexImageSize" [galleryName]="yourGalleryName"></gallery>`

Hope this solves the external data source issue #22 